### PR TITLE
Bug fix in gettig stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports.deleteUnusedChannels = function deleteUnusedChannels(host, topic,
     json   : true
   }
 
-  request.post(endpoint, options, function(err, response, body) {
+  request.get(endpoint, options, function(err, response, body) {
     if(err) return callback(err);
 
     var nsqTopics      = body.data.topics;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,11 +13,13 @@ describe('nsq-cleanup', function(){
       host  : 'http://127.0.0.1:4151',
       topic : 'sample_topic'
     };
+    sinon.stub(request, 'get');
     sinon.stub(request, 'post');
   });
 
 
   afterEach(function(){
+    request.get.restore();
     request.post.restore();
   });
 
@@ -56,7 +58,7 @@ describe('nsq-cleanup', function(){
       }
     };
 
-    request.post.yields(null, {body: body}, body);
+    request.get.yields(null, {body: body}, body);
     sinon.stub(lib, 'deleteChannel').yields(null);
 
     lib.deleteUnusedChannels(options.host, options.topic, function(err, count){


### PR DESCRIPTION
cc @TabDigital/ping-api 
Apparently new version of NSQ supports GET request for `/stats`, I'm sure that in older versions it was supporting post, anyway it's not a good idea to send a `POST` request to the endpoint so I changed it to be `GET`
